### PR TITLE
Blender 4.4 Guide Widget Fix

### DIFF
--- a/guides/guide_wg.py
+++ b/guides/guide_wg.py
@@ -101,7 +101,8 @@ class BlenrigGuideFunctions:
 
 
 class BLENRIG_WG_guide(BlenrigGuideFunctions):
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         context = bpy.context
         self.needs_update = True
         self.needs_call_action_safe = False

--- a/ops_baking.py
+++ b/ops_baking.py
@@ -476,7 +476,7 @@ class ARMATURE_OT_armature_baker_all_part_1(bpy.types.Operator):
         bpy.ops.object.mode_set(mode='EDIT')
         bpy.ops.blenrig.fix_misaligned_bones()
         bpy.ops.blenrig.auto_bone_roll()
-        bpy.ops.armature.collection_solo_visibility(name="BONE-ROLLS")
+        context.object.data.collections_all["BONE-ROLLS"].is_solo = True
         context.object.data.show_axes = True
         context.scene.cursor.location = [0,0,0]
 
@@ -503,7 +503,7 @@ class ARMATURE_OT_armature_baker_all_part_2(bpy.types.Operator):
         bpy.ops.blenrig.custom_bone_roll()
         bpy.ops.blenrig.store_roll_angles()
         context.object.data.show_axes = False
-        bpy.ops.armature.collection_solo_visibility(name="REPROPORTION")
+        context.object.data.collections_all["REPROPORTION"].is_solo = True
         bpy.ops.object.mode_set(mode='POSE')
         bpy.ops.blenrig.reset_constraints()
         context.object.data.pose_position = 'REST'

--- a/ops_baking.py
+++ b/ops_baking.py
@@ -259,7 +259,7 @@ class ARMATURE_OT_reset_deformers(bpy.types.Operator):
             if ob.type in 'LATTICE' or 'CURVE':
                 for mod in ob.modifiers:
                     if mod.type in 'HOOK':
-                        if mod.object.name == bpy.context.object.name:
+                        if mod.object and mod.object.name == bpy.context.object.name:
                             # Toggle on active collections
                             for coll in bpy.data.collections:
                                 for coll_ob in coll.objects:

--- a/search_functions.py
+++ b/search_functions.py
@@ -27,26 +27,11 @@ def mdef_search(type):
                             if hasattr(cage, 'modifiers'):
                                 for mod in cage.modifiers:
                                     if mod.type == 'ARMATURE':
-                                        if mod.object.name == arm:
+                                        if mod.object and mod.object.name == arm:
                                             if bpy.data.objects.get(ob.modifiers[ob_m.name].object.name) not in mdef_cage_objects:
                                                 mdef_cage_objects.append(bpy.data.objects.get(ob.modifiers[ob_m.name].object.name))
                                                 mdef_cage_names.append(ob.modifiers[ob_m.name].object.name)
     return mdef_cage_objects , mdef_cage_names
-    for ob in bpy.data.objects:
-        if hasattr(ob,'modifiers'):
-            for ob_m in ob.modifiers:
-                if type == 'SURFACE_DEFORM':
-                    if ob_m.type == type:
-                        if hasattr(ob.modifiers[ob_m.name], 'target') and hasattr(ob.modifiers[ob_m.name].target, 'name'):
-                            cage = ob.modifiers[ob_m.name].target
-                            if hasattr(cage, 'modifiers'):
-                                for mod in cage.modifiers:
-                                    if mod.type == 'ARMATURE':
-                                        if mod.object.name == arm:
-                                            if bpy.data.objects.get(ob.modifiers[ob_m.name].target.name) not in sdef_cage_objects:
-                                                sdef_cage_objects.append(bpy.data.objects.get(ob.modifiers[ob_m.name].target.name))
-                                                sdef_cage_objects.append(ob.modifiers[ob_m.name].target.name)
-    return sdef_cage_objects , sdef_cage_names
 
 ###### Search objets with modifiers  #####
 def search_mod(type):


### PR DESCRIPTION
https://docs.blender.org/api/4.4/info_overview.html#construction-destruction

I am not sure about backwards compatibility. But without this change the guide will not show up in Blender 4.4 .